### PR TITLE
👷 topicLimit now dynamically by runtime argument

### DIFF
--- a/.github/workflows/fetch-projects-by-topic.yml
+++ b/.github/workflows/fetch-projects-by-topic.yml
@@ -43,9 +43,9 @@ jobs:
         run: |
           pnpm install -g typescript ts-node
 
-      - name: Execute script
+      - name: Fetch first 1000 projects
         run: |
-          ts-node --esm scripts/actions/fetch-projects-by-topic.ts
+          ts-node --esm scripts/actions/fetch-projects-by-topic.ts 1000
 
       - name: Add, commit and push to the repository
         uses: stefanzweifel/git-auto-commit-action@v5


### PR DESCRIPTION
add support for dynamic `topicLimit` by workflows runtime argument
```yaml
...
      - name: Fetch first 1000 projects
        run: |
          ts-node --esm scripts/actions/fetch-projects-by-topic.ts 1000
...
```